### PR TITLE
sample for langchain4j-chatmemory-oracle

### DIFF
--- a/langchain4j-chatmemory-oracle-example/.gitignore
+++ b/langchain4j-chatmemory-oracle-example/.gitignore
@@ -1,0 +1,45 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+.kotlin
+
+### IntelliJ IDEA ###
+.idea/*
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+.idea/inspectionProfiles/Project_Default.xml
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store
+
+###Wallet###
+
+

--- a/langchain4j-chatmemory-oracle-example/README.md
+++ b/langchain4j-chatmemory-oracle-example/README.md
@@ -1,0 +1,63 @@
+# LangChain4j Oracle ChatMemory Sample
+
+This project demonstrates:
+
+- `MessageWindowChatMemory` with Oracle-backed persistence (`OracleMemoryStore` from `langchain4j-oracle`)
+- Tool-enabled assistant (`Demotools`)
+- Custom metadata message (`CustomMessage`) added to memory
+
+Main sample entrypoint:
+
+- `src/main/sample/java/dev/langchain4j/Main.java`
+
+## What You Need
+
+1. Java 21
+2. Maven 3.9+
+3. Oracle DB access (connection URL, user, password)
+4. Ollama running locally or remotely with model `qwen3:8b`
+5. Sibling project available at `../langchain4j-oracle` (already in your workspace)
+
+## Required Environment Variables
+
+Set these before running:
+
+```bash
+export OLLAMA_BASE_URL=http://localhost:11434
+export url='jdbc:oracle:thin:@YOUR_DB_ALIAS?TNS_ADMIN=/absolute/path/to/Wallet_MemoryStore'
+export user='YOUR_DB_USER'
+export password='YOUR_DB_PASSWORD'
+```
+
+Notes:
+
+- Variable names must be exactly: `OLLAMA_BASE_URL`, `url`, `user`, `password`
+- `OracleWalletDataSourceFactory` reads these exact names
+
+## Build Oracle Integration Module (one-time or after changes)
+
+From this project root:
+
+```bash
+cd ../langchain4j-oracle
+mvn -DskipTests install
+cd ../langchain4j-Chatmemory
+```
+
+This installs `dev.langchain4j:langchain4j-oracle:1.12.0-SNAPSHOT` into your local Maven repository.
+
+## Build This Project
+
+```bash
+mvn -DskipTests compile
+```
+
+## Run The Sample
+
+### IntelliJ (recommended)
+
+1. Open `src/main/sample/java/dev/langchain4j/Main.java`
+2. Run `Main.main()`
+3. Chat in terminal, type `exit` or `quit` to stop
+
+

--- a/langchain4j-chatmemory-oracle-example/pom.xml
+++ b/langchain4j-chatmemory-oracle-example/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4jChatmemory</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <langchain4j.version>1.12.2</langchain4j.version>
+    </properties>
+<dependencies>
+
+    <dependency>
+        <groupId>com.oracle.database.jdbc</groupId>
+        <artifactId>ojdbc11</artifactId>
+        <version>23.5.0.24.07</version>
+    </dependency>
+    <dependency>
+        <groupId>com.oracle.database.jdbc</groupId>
+        <artifactId>ojdbc-provider-jackson-oson</artifactId>
+        <version>1.0.6</version>
+    </dependency>
+    <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>2.0.13</version>
+        <scope>runtime</scope>
+    </dependency>
+    <dependency>
+        <groupId>com.oracle.database.security</groupId>
+        <artifactId>oraclepki</artifactId>
+        <version>21.5.0.0</version>
+        <scope>runtime</scope>
+    </dependency>
+    <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-core</artifactId>
+        <version>1.12.2</version>
+    </dependency>
+
+    <dependency>
+        <groupId>com.oracle.database.security</groupId>
+        <artifactId>osdt_cert</artifactId>
+        <version>21.5.0.0</version>
+        <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+        <groupId>com.oracle.database.security</groupId>
+        <artifactId>osdt_core</artifactId>
+        <version>21.5.0.0</version>
+        <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j</artifactId>
+        <version>${langchain4j.version}</version>
+    </dependency>
+
+    <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-oracle</artifactId>
+        <version>1.12.0-SNAPSHOT</version>
+    </dependency>
+
+
+    <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>1.18.32</version>
+        <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+        <groupId>org.apache.pdfbox</groupId>
+        <artifactId>pdfbox</artifactId>
+        <version>2.0.30</version>
+    </dependency>
+
+
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-open-ai</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-ollama</artifactId>
+        </dependency>
+
+</dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-bom</artifactId>
+                <version>${langchain4j.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/langchain4j-chatmemory-oracle-example/src/main/java/dev/langchain4j/OracleWalletDataSourceFactory.java
+++ b/langchain4j-chatmemory-oracle-example/src/main/java/dev/langchain4j/OracleWalletDataSourceFactory.java
@@ -1,0 +1,22 @@
+package dev.langchain4j;
+
+import oracle.jdbc.pool.OracleDataSource;
+
+
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+/*
+Connect to Oracle DB
+ */
+public class OracleWalletDataSourceFactory {
+    public static OracleDataSource createconnection() throws SQLException {
+      OracleDataSource oracleDataSource=new OracleDataSource();
+
+        oracleDataSource.setURL(System.getenv("url"));
+        oracleDataSource.setUser(System.getenv("user"));
+        oracleDataSource.setPassword(System.getenv("password"));
+
+        return oracleDataSource;
+    }
+}

--- a/langchain4j-chatmemory-oracle-example/src/main/sample/java/dev/langchain4j/Assistant.java
+++ b/langchain4j-chatmemory-oracle-example/src/main/sample/java/dev/langchain4j/Assistant.java
@@ -1,0 +1,7 @@
+package dev.langchain4j;
+import dev.langchain4j.service.SystemMessage;
+
+public interface Assistant {
+    @SystemMessage("You are a helpful assistant")
+    String chat(String userMessage);
+}

--- a/langchain4j-chatmemory-oracle-example/src/main/sample/java/dev/langchain4j/Demotools.java
+++ b/langchain4j-chatmemory-oracle-example/src/main/sample/java/dev/langchain4j/Demotools.java
@@ -1,0 +1,12 @@
+package dev.langchain4j;
+
+import dev.langchain4j.agent.tool.Tool;
+import java.time.Instant;
+
+public class Demotools {
+
+    @Tool("Returns the current time in UTC as ISO-8601")
+    public String currentTimeUtc() {
+        return Instant.now().toString();
+    }
+}

--- a/langchain4j-chatmemory-oracle-example/src/main/sample/java/dev/langchain4j/Main.java
+++ b/langchain4j-chatmemory-oracle-example/src/main/sample/java/dev/langchain4j/Main.java
@@ -1,0 +1,86 @@
+package dev.langchain4j;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.CustomMessage;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Scanner;
+
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.ollama.OllamaChatModel;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.store.chatmemory.oracle.OracleMemoryStore;
+
+public class Main {
+    public static void main(String[] args) throws SQLException {
+
+        ChatModel model = OllamaChatModel.builder()
+                .baseUrl(System.getenv("OLLAMA_BASE_URL"))
+                .modelName("qwen3:8b")
+                .build();
+
+        // Create a memory store backed by Oracle DB using wallet-based datasource/connection
+
+        OracleMemoryStore memorystore = OracleMemoryStore.builder()
+                .dataSource(OracleWalletDataSourceFactory.createconnection())
+                .tableName("sample")
+                .ttl(Duration.ofSeconds(40))
+                .build();
+
+        // A stable identifier for the conversation session/user.
+
+        String memoryId = "user123-session0";
+
+        // In-memory window on top of the persistent store
+
+        ChatMemory chatMemory = MessageWindowChatMemory.builder()
+                .id(memoryId)
+                .maxMessages(20)
+                .chatMemoryStore(memorystore)
+                .build();
+
+
+        // Build an AI service that maps assistant interface methods to LLM calls
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .chatMemory(chatMemory)
+                .tools(new Demotools())
+                .build();
+
+        CustomMessage customMessage = CustomMessage.from(Map.of(
+                "event", "TOOL_EXECUTION_RESULT",
+                "toolCallId", "tool_call_001",
+                "isError", true,
+                "error", "Tool timeout",
+                "fallbackQuestion", "I could not run the tool. Do you want me to continue without it?"
+        ));
+        System.out.println("Sample CustomMessage: " + customMessage);
+        chatMemory.add(customMessage);
+
+        System.out.println("Chat started. Type your message and press Enter.");
+        System.out.println("Type 'exit' or 'quit' to stop.");
+
+        try (Scanner scanner = new Scanner(System.in)) {
+            while (true) {
+                System.out.print("You: ");
+                if (!scanner.hasNextLine()) {
+                    break;
+                }
+                String userInput = scanner.nextLine().trim();
+                if (userInput.isEmpty()) {
+                    continue;
+                }
+                if ("exit".equalsIgnoreCase(userInput) || "quit".equalsIgnoreCase(userInput)) {
+                    System.out.println("Bye.");
+                    break;
+                }
+
+                String answer = assistant.chat(userInput);
+                System.out.println("Bot: " + answer);
+            }
+        }
+    }
+}

--- a/spring-boot-langchain4j-chatmemory-oracle-example/.gitignore
+++ b/spring-boot-langchain4j-chatmemory-oracle-example/.gitignore
@@ -1,0 +1,45 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+.kotlin
+
+### IntelliJ IDEA ###
+.idea/*
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+.idea/inspectionProfiles/Project_Default.xml
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store
+
+###Wallet###
+
+

--- a/spring-boot-langchain4j-chatmemory-oracle-example/README.md
+++ b/spring-boot-langchain4j-chatmemory-oracle-example/README.md
@@ -1,0 +1,184 @@
+# Spring Boot LangChain4j Oracle Chat Memory (Auto-Configuration)
+
+Spring Boot example that auto-configures a LangChain4j assistant with Oracle-backed chat memory persistence.
+
+This app demonstrates:
+
+- `@AiService`-driven assistant creation (no manual `AiServices.builder(...)`)
+- Ollama chat model auto-configuration
+- `MessageWindowChatMemory` auto-configuration
+- Oracle `ChatMemoryStore` auto-configuration and persistence
+
+## Requirements
+
+- Java 21+
+- Maven 3.9+
+- Oracle Database access (JDBC URL, username, password)
+- Ollama server (local or remote)
+- Local sibling module `../langchain4j-oracle` available and installed
+
+## Installation
+
+Install the local Oracle integration module used by this example:
+
+```bash
+cd ../langchain4j-oracle
+mvn -DskipTests install
+cd ../spring-boot-langchain4j-chatmemory-oracle-example
+```
+
+Build this app:
+
+```bash
+mvn -DskipTests compile
+```
+
+## Quick Start
+
+Set environment variables:
+
+```bash
+export OLLAMA_BASE_URL=http://localhost:11434
+export OLLAMA_MODEL_NAME=qwen3:8b
+
+export ORACLE_JDBC_URL='jdbc:oracle:thin:@YOUR_DB_ALIAS?TNS_ADMIN=/absolute/path/to/Wallet_MemoryStore'
+export ORACLE_JDBC_USER='YOUR_DB_USER'
+export ORACLE_JDBC_PASSWORD='YOUR_DB_PASSWORD'
+
+# Optional
+export ORACLE_CHAT_MEMORY_TABLE=chat_memory_test
+```
+
+Run:
+
+```bash
+mvn spring-boot:run
+```
+
+CLI usage:
+- Type your message and press Enter
+- Type `exit` or `quit` to stop
+
+## Auto-Configured Components
+
+### Assistant
+
+The `@AiService` interface is auto-implemented and injected:
+- `src/main/java/dev/langchain4j/Assistant.java`
+
+### Chat Model
+
+Ollama chat model is configured from:
+- `langchain4j.ollama.chat-model.*`
+
+### Chat Memory
+
+Message window memory is configured from:
+- `langchain4j.chat-memory.type`
+- `langchain4j.chat-memory.max-messages`
+
+### Oracle Chat Memory Store
+
+Oracle-backed persistence is configured from:
+- `langchain4j.community.oracle.chat-memory.*`
+
+## Configuration Properties
+
+The app configuration lives in `src/main/resources/application.yml`.
+
+### Spring DataSource
+
+| Property | Default in this app | Description |
+| --- | --- | --- |
+| `spring.datasource.url` | `${ORACLE_JDBC_URL:${url}}` | Oracle JDBC URL. |
+| `spring.datasource.username` | `${ORACLE_JDBC_USER:${user}}` | Oracle DB username. |
+| `spring.datasource.password` | `${ORACLE_JDBC_PASSWORD:${password}}` | Oracle DB password. |
+| `spring.datasource.driver-class-name` | `oracle.jdbc.OracleDriver` | Oracle JDBC driver class. |
+
+Legacy fallbacks supported by this app:
+- `url` (fallback for `ORACLE_JDBC_URL`)
+- `user` (fallback for `ORACLE_JDBC_USER`)
+- `password` (fallback for `ORACLE_JDBC_PASSWORD`)
+
+### Ollama Model
+
+Prefix: `langchain4j.ollama.chat-model`
+
+| Property | Default in this app | Description |
+| --- | --- | --- |
+| `base-url` | `${OLLAMA_BASE_URL:http://localhost:11434}` | Ollama endpoint. |
+| `model-name` | `${OLLAMA_MODEL_NAME:qwen3:8b}` | Model used for chat completion. |
+
+### Chat Memory Window
+
+Prefix: `langchain4j.chat-memory`
+
+| Property | Default in this app | Description |
+| --- | --- | --- |
+| `type` | `message-window` | Chat memory strategy used by the assistant. |
+| `max-messages` | `20` | Max messages kept in window before eviction. |
+
+### Oracle Chat Memory Store
+
+Prefix: `langchain4j.community.oracle.chat-memory`
+
+| Property | Default in this app | Description |
+| --- | --- | --- |
+| `enabled` | `true` | Enables Oracle chat memory auto-configuration. |
+| `table-name` | `${ORACLE_CHAT_MEMORY_TABLE:chat_memory_test}` | Oracle table used for persisted memory entries. |
+| `ttl` | implementation default | Optional time-to-live for memory entries (if set in your starter/library version). |
+
+Duration examples for `ttl`:
+- ISO-8601: `PT1H`, `PT24H`
+- Simple suffixes: `30s`, `5m`, `1h`, `7d`
+
+## Full Example `application.yml`
+
+```yaml
+spring:
+  datasource:
+    url: ${ORACLE_JDBC_URL:${url}}
+    username: ${ORACLE_JDBC_USER:${user}}
+    password: ${ORACLE_JDBC_PASSWORD:${password}}
+    driver-class-name: oracle.jdbc.OracleDriver
+
+langchain4j:
+  ollama:
+    chat-model:
+      base-url: ${OLLAMA_BASE_URL:http://localhost:11434}
+      model-name: ${OLLAMA_MODEL_NAME:qwen3:8b}
+  chat-memory:
+    type: message-window
+    max-messages: 20
+  community:
+    oracle:
+      chat-memory:
+        enabled: true
+        table-name: ${ORACLE_CHAT_MEMORY_TABLE:chat_memory_test}
+        # Optional in versions that support it:
+        # ttl: 7d
+```
+
+## Disabling Oracle Chat Memory
+
+Disable Oracle chat memory store auto-configuration:
+
+```yaml
+langchain4j:
+  community:
+    oracle:
+      chat-memory:
+        enabled: false
+```
+
+## Project Layout
+
+```text
+src/main/java/dev/langchain4j/
+  Assistant.java
+  ChatMemoryOracleApplication.java
+  Demotools.java
+
+src/main/resources/
+  application.yml
+```

--- a/spring-boot-langchain4j-chatmemory-oracle-example/pom.xml
+++ b/spring-boot-langchain4j-chatmemory-oracle-example/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4jChatmemory</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <java.version>21</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spring.boot.version>3.4.0</spring.boot.version>
+        <langchain4j.version>1.12.2</langchain4j.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-bom</artifactId>
+                <version>${langchain4j.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-ollama-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-oracle</artifactId>
+            <version>1.12.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc11</artifactId>
+            <version>23.5.0.24.07</version>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc-provider-jackson-oson</artifactId>
+            <version>1.0.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.security</groupId>
+            <artifactId>oraclepki</artifactId>
+            <version>21.5.0.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.security</groupId>
+            <artifactId>osdt_cert</artifactId>
+            <version>21.5.0.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.security</groupId>
+            <artifactId>osdt_core</artifactId>
+            <version>21.5.0.0</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring-boot-langchain4j-chatmemory-oracle-example/src/main/java/dev/langchain4j/Assistant.java
+++ b/spring-boot-langchain4j-chatmemory-oracle-example/src/main/java/dev/langchain4j/Assistant.java
@@ -1,0 +1,11 @@
+package dev.langchain4j;
+
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.spring.AiService;
+
+@AiService
+public interface Assistant {
+
+    @SystemMessage("You are a helpful assistant")
+    String chat(String userMessage);
+}

--- a/spring-boot-langchain4j-chatmemory-oracle-example/src/main/java/dev/langchain4j/ChatMemoryOracleApplication.java
+++ b/spring-boot-langchain4j-chatmemory-oracle-example/src/main/java/dev/langchain4j/ChatMemoryOracleApplication.java
@@ -1,0 +1,44 @@
+package dev.langchain4j;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import java.util.Scanner;
+
+@SpringBootApplication
+public class ChatMemoryOracleApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ChatMemoryOracleApplication.class, args);
+    }
+
+    @Bean
+    CommandLineRunner chatRunner(Assistant assistant) {
+        return args -> {
+            System.out.println("Chat started. Type your message and press Enter.");
+            System.out.println("Type 'exit' or 'quit' to stop.");
+
+            try (Scanner scanner = new Scanner(System.in)) {
+                while (true) {
+                    System.out.print("You: ");
+                    if (!scanner.hasNextLine()) {
+                        break;
+                    }
+                    String userInput = scanner.nextLine().trim();
+                    if (userInput.isEmpty()) {
+                        continue;
+                    }
+                    if ("exit".equalsIgnoreCase(userInput) || "quit".equalsIgnoreCase(userInput)) {
+                        System.out.println("Bye.");
+                        break;
+                    }
+
+                    String answer = assistant.chat(userInput);
+                    System.out.println("Bot: " + answer);
+                }
+            }
+        };
+    }
+}

--- a/spring-boot-langchain4j-chatmemory-oracle-example/src/main/java/dev/langchain4j/Demotools.java
+++ b/spring-boot-langchain4j-chatmemory-oracle-example/src/main/java/dev/langchain4j/Demotools.java
@@ -1,0 +1,15 @@
+package dev.langchain4j;
+
+import dev.langchain4j.agent.tool.Tool;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+@Component
+public class Demotools {
+
+    @Tool("Returns the current time in UTC as ISO-8601")
+    public String currentTimeUtc() {
+        return Instant.now().toString();
+    }
+}

--- a/spring-boot-langchain4j-chatmemory-oracle-example/src/main/resources/application.yml
+++ b/spring-boot-langchain4j-chatmemory-oracle-example/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    url: ${ORACLE_JDBC_URL:${url}}
+    username: ${ORACLE_JDBC_USER:${user}}
+    password: ${ORACLE_JDBC_PASSWORD:${password}}
+    driver-class-name: oracle.jdbc.OracleDriver
+
+langchain4j:
+  ollama:
+    chat-model:
+      base-url: ${OLLAMA_BASE_URL:http://localhost:11434}
+      model-name: ${OLLAMA_MODEL_NAME:qwen3:8b}
+  chat-memory:
+    type: message-window
+    max-messages: 20
+  community:
+    oracle:
+      chat-memory:
+        enabled: true
+        table-name: ${ORACLE_CHAT_MEMORY_TABLE:chat_memory_test}


### PR DESCRIPTION
This project is a LangChain4j sample that uses Oracle-backed ChatMemory with an interactive assistant loop.
It connects to an Ollama chat model, supports tool calls (Demotools), and persists conversation state in Oracle DB.
It also demonstrates custom workflow metadata in memory (CustomMessage) for cases like tool-failure fallback handling.